### PR TITLE
Make linting safe.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -19,9 +19,11 @@ module.exports = class CoffeeLinter
     @pattern = cfg.pattern ? ///^#{@config.paths.app}.*\.coffee$///
 
   lint: (data, path, callback) ->
-    error = (linter.lint data, @options, @globals)
+    error = try
+      (linter.lint data, @options, @globals)
         .filter((error) -> error?)
         .map(formatError)
         .join('\n')
+    catch err
+      err
     if error then callback error else callback()
-


### PR DESCRIPTION
Sometimes linting crashes brunch process because of invalid coffeescript code.

```
node_modules/coffeelint-brunch/node_modules/coffee-script/lib/coffee-script/lexer.js:682
      throw SyntaxError("" + message + " on line " + (this.line + 1));
            ^
SyntaxError: unmatched OUTDENT on line 20
    at SyntaxError (unknown source)
```
