### PR TITLE
Fix coffeelint no longer accepting globals parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,14 +19,14 @@ module.exports = CoffeeLinter = (function() {
   CoffeeLinter.prototype.extension = 'coffee';
 
   function CoffeeLinter(config) {
-    var cfg, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
+    var cfg, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8;
     this.config = config;
     cfg = (_ref = (_ref1 = (_ref2 = this.config) != null ? (_ref3 = _ref2.plugins) != null ? _ref3.coffeelint : void 0 : void 0) != null ? _ref1 : (_ref4 = this.config) != null ? _ref4.coffeelint : void 0) != null ? _ref : {};
     if ((_ref5 = this.config) != null ? _ref5.coffeelint : void 0) {
       console.warn("Warning: config.coffeelint is deprecated, move it to config.plugins.coffeelint");
     }
     this.options = cfg.options;
-    this.pattern = (_ref6 = cfg.pattern) != null ? _ref6 : RegExp("^(" + (this.config.paths.watch.join("|")) + ").*\\.coffee$");
+    this.pattern = (_ref6 = cfg.pattern) != null ? _ref6 : RegExp("(" + (((_ref7 = this.config.paths) != null ? (_ref8 = _ref7.watched) != null ? _ref8.join("|") : void 0 : void 0) || "app") + ").*\\.coffee$");
   }
 
   CoffeeLinter.prototype.lint = function(data, path, callback) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -19,7 +19,7 @@ module.exports = class CoffeeLinter
       console.warn "Warning: config.coffeelint is deprecated, move it to config.plugins.coffeelint"
 
     @options = cfg.options
-    @pattern = cfg.pattern ? ///^(#{@config.paths.watch.join("|")}).*\.coffee$///
+    @pattern = cfg.pattern ? ///(#{@config.paths?.watched?.join("|") or "app"}).*\.coffee$///
 
   lint: (data, path, callback) ->
     error = try

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -3,7 +3,6 @@ describe('Plugin', function() {
 
   beforeEach(function() {
     plugin = new Plugin({
-      paths: {watch: ['app']},
       plugins: {
         coffeelint: {
           options: {no_trailing_semicolons: { level: "ignore"} }


### PR DESCRIPTION
Had to make a few updates to support `config.paths.watched` being an array and remove the globals property which was preventing the lint from working.

All tests passing now.
