### PR TITLE
Bumps version to 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# coffeelint-brunch 1.7.1 (September 21, 2015)
+* Adds ability to use coffeelint.json
+
 # coffeelint-brunch 1.7.0 (April 15, 2014)
 * Made compatible with brunch 1.7.x
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Or, do manual install:
 
 By default, only files in your `config.paths.app` are linted.
 
-You can customize jshint config by changing brunch config using the native [coffeelint options](http://www.coffeelint.org/#options):
+You can customize coffeelint config by changing brunch config using the native [coffeelint options](http://www.coffeelint.org/#options):
 
 ```coffeescript
 config =
@@ -26,7 +26,18 @@ config =
           level: "ignore"
 ```
 
-Every sub-option (`pattern`, `options`, `globals`) is optional.
+You can also use the standard `coffeelint.json` file instead of adding exceptions in the brunch config:
+
+```coffeescript
+config =
+  plugins:
+    coffeelint:
+      useCoffeelintJson: yes
+```
+
+In the second case, any rules in `plugins.coffeelint.options` are ignored and instead coffeelint is supplied with the contents of the `coffeelint.json` file found in the root directory as the configuration object.
+
+Every sub-option (`pattern`, `options`, `useCoffeelintJson`, `globals`) is optional.
 
 ## License <a name="license" href="#license" title="Link to this section">⚑</a>
 Copyright (c) 2012 "ilkosta" Costantino Giuliodori.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coffeelint-brunch",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Adds CoffeeLint support to brunch.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Please merge and publish to NPM so the new `useCoffeelintJson` option can be used after an `npm install`.

This PR also adds some documentation on the new option to the readme.