### PR TITLE
Upgrade coffeelint dependency to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
-    "coffeelint": "~1.14.2"
+    "coffeelint": "~1.16.0"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
This version uses new glob library. There was some warnings regarding old glob lib that is using minimap with some RegExp Dos issue.